### PR TITLE
Added scam websites to the blocklist

### DIFF
--- a/src/config.json
+++ b/src/config.json
@@ -511,6 +511,8 @@
     "launchpad.ethereum.org"
   ],
   "blacklist": [
+    "dappradar.zone",
+    "dappradar.click",
     "bayc.team",
     "ticket20312-coinbase.com",
     "layer-zero0.pro",


### PR DESCRIPTION
Added 2 scam domains to the blocklist. Official domain is dappradar.com stay vigilant.